### PR TITLE
Hack env

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,9 @@
+FROM archlinux:latest
+
+RUN pacman -Syu --noconfirm \
+ && pacman -S --noconfirm python python-pip python-pyzmq python-pyflakes helix \
+ && pip install --break-system-packages base58 toml pyasyncore asyncio
+
+ENV EDITOR=hx
+
+WORKDIR /src

--- a/qa/pull-tester/rpc-tests.py
+++ b/qa/pull-tester/rpc-tests.py
@@ -208,6 +208,7 @@ def main():
     parser.add_argument('--deterministic', '-d', action='store_true', help='make the output a bit closer to deterministic in order to compare runs.')
     parser.add_argument('--exclude', '-x', help='specify a comma-separated-list of scripts to exclude. Do not include the .py extension in the name.')
     parser.add_argument('--extended', action='store_true', help='run the extended test suite in addition to the basic tests')
+    parser.add_argument('--new-only', action='store_true', help='run only the NEW_SCRIPTS tests')
     parser.add_argument('--force', '-f', action='store_true', help='run tests even on platforms where they are disabled by default (e.g. windows).')
     parser.add_argument('--help', '-h', '-?', action='store_true', help='print help text and exit')
     parser.add_argument('--jobs', '-j', type=int, default=4, help='how many test scripts to run in parallel. Default=4.')
@@ -260,6 +261,8 @@ def main():
         print("Running individually selected tests: ")
         for t in test_list:
             print("\t" + t)
+    elif args.new_only:
+        test_list = NEW_SCRIPTS
     else:
         # No individual tests have been specified. Run base tests, and
         # optionally ZMQ tests and extended tests.

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -1116,7 +1116,7 @@ def start_zaino(i, dirname, extra_args=None, rpchost=None, timewait=None, binary
     if binary is None:
         binary = zaino_binary()
     config = update_zainod_conf(datadir, rpc_port(i), indexer_rpc_port(i), zaino_rpc_port(i), zaino_grpc_port(i), extra_args)
-    args = [ binary, "-c="+config ]
+    args = [ binary, "start", "-c="+config ]
 
     zainod_processes[i] = subprocess.Popen(args, stderr=stderr)
     if os.getenv("PYTHON_DEBUG", ""):

--- a/qa/rpc-tests/test_framework/util.py
+++ b/qa/rpc-tests/test_framework/util.py
@@ -217,7 +217,7 @@ def update_zebrad_conf(datadir, rpc_port, p2p_port, indexer_port, extra_args=Non
         rpc_listen_address='127.0.0.1:'+str(rpc_port),
         indexer_listen_address='127.0.0.1:'+str(indexer_port),
         data_dir=datadir,
-        extra_args=extra_args)
+        extra_args=extra_args if isinstance(extra_args, ZebraArgs) else None)
 
     config_file = zebra_config.update(config_file)
 


### PR DESCRIPTION
Here's a collection of the hacks I used yesterday.

I built and copied the whole binaries zebrad, zainod, and zallet into the target "src" directory.

I matched the podman image base to my host so that dynamically linked libraries in Zallet would find appropriate symbols.

I ran with this:

```bash
podman build -t zcash-tests .
podman run --rm -it --userns=keep-id -v .:/src:Z zcash-tests bash
```